### PR TITLE
fix bugs at the edge of integer space

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ This will permit these parameters:
 | Parameters.lte(10)             | value <= 10                                                             |
 | Parameters.gt(0)               | value > 0                                                               |
 | Parameters.gte(0)              | value >= 0                                                              |
-| Parameters.integer32           | Parameters.integer & Parameters.lte(2 ** 31) & Parameters.gte(-2 ** 31) |
-| Parameters.integer64           | Parameters.integer & Parameters.lte(2 ** 63) & Parameters.gte(-2 ** 63) |
-| Parameters.id                  | Parameters.integer & Parameters.lte(2 ** 31) & Parameters.gte(0)        |
-| Parameters.bigid               | Parameters.integer & Parameters.lte(2 ** 63) & Parameters.gte(0)        |
+| Parameters.integer32           | Parameters.integer & Parameters.lt(2 ** 32) & Parameters.gt(-2 ** 32)   |
+| Parameters.integer64           | Parameters.integer & Parameters.lt(2 ** 64) & Parameters.gt(-2 ** 64)   |
+| Parameters.id                  | Parameters.integer & Parameters.lt(2 ** 32) & Parameters.gte(0)         |
+| Parameters.bigid               | Parameters.integer & Parameters.lt(2 ** 64) & Parameters.gte(0)         |
 | Parameters.boolean             | Parameters.enum(true, false, 'true', 'false', 1, 0)                     |

--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -48,19 +48,19 @@ module StrongerParameters
       end
 
       def integer32
-        integer & lte(2 ** 31) & gte(-2 ** 31)
+        integer & lt(2 ** 32) & gt(-2 ** 32)
       end
 
       def integer64
-        integer & lte(2 ** 63) & gte(-2 ** 63)
+        integer & lt(2 ** 64) & gt(-2 ** 64)
       end
 
       def id
-        integer & lte(2 ** 31) & gte(0)
+        integer & lt(2 ** 32) & gte(0)
       end
 
       def bigid
-        integer & lte(2 ** 63) & gte(0)
+        integer & lt(2 ** 64) & gte(0)
       end
 
       def enumeration(*allowed)


### PR DESCRIPTION
@staugaard @apanzerj 

if we have 4 bits -> `2**4 = 16` -> we can store 0-15 -> we cannot store 16 and `2**3 = 8` would discard 1 bit