### PR TITLE
Always force params to follow constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ params.permit(
 
 This will allow an array of id parameters that all are IDs.
 
-> Please notice that prior Rails 4.1 empty arrays will be considered to be invalid, because Rails will convert empty array to nil. In Rails 4.1+ you can set `config.action_dispatch.perform_deep_munge = false` to avoid this behaviour and accept empty arrays as valid valud.
+Please notice that prior Rails 4.1 empty arrays will be considered to be invalid, because Rails will convert empty array to nil. In Rails 4.1+ you can set `config.action_dispatch.perform_deep_munge = false` to avoid this behaviour and accept empty arrays as valid value.
 
 ## Nested Parameters
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ params.permit(
 
 This will allow an array of id parameters that all are IDs.
 
-Please notice that prior Rails 4.1 empty arrays will be considered to be invalid, because Rails will convert empty array to nil. In Rails 4.1+ you can set `config.action_dispatch.perform_deep_munge = false` to avoid this behaviour and accept empty arrays as valid value.
+### Empty array -> nil
+Rails converts empty arrays to nil unless `config.action_dispatch.perform_deep_munge = false` is set
+(available in Rails 4.1+). Either use this or `Parameters.array | Parameters.nil` to deal with this.
 
 ## Nested Parameters
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ params.permit(
 
 This will allow an array of id parameters that all are IDs.
 
+> Please notice that prior Rails 4.1 empty arrays will be considered to be invalid, because Rails will convert empty array to nil. In Rails 4.1+ you can set `config.action_dispatch.perform_deep_munge = false` to avoid this behaviour and accept empty arrays as valid valud.
+
 ## Nested Parameters
 
 ```ruby

--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -96,10 +96,6 @@ module StrongerParameters
       hash_filter_without_stronger_parameters(params, other_filter)
 
       slice(*stronger_filter.keys).each do |key, value|
-        if value.nil?
-          params[key] = nil
-          next
-        end
 
         constraint = stronger_filter[key]
         begin

--- a/test/array_contraints_test.rb
+++ b/test/array_contraints_test.rb
@@ -9,4 +9,6 @@ describe 'array parameter constraints' do
   rejects 123
   rejects [123, 456]
   rejects ['abc', 123]
+  rejects nil
+  rejects [nil]
 end

--- a/test/boolean_constraints_test.rb
+++ b/test/boolean_constraints_test.rb
@@ -14,4 +14,5 @@ describe 'boolean parameter constraints' do
   permits '0',     :as => false
 
   rejects 'foo'
+  rejects nil
 end

--- a/test/enum_constraints_test.rb
+++ b/test/enum_constraints_test.rb
@@ -9,4 +9,5 @@ describe 'enum parameter constraints' do
   rejects 'abcd'
   rejects '123'
   rejects 1234
+  rejects nil
 end

--- a/test/integer_constraints_test.rb
+++ b/test/integer_constraints_test.rb
@@ -11,4 +11,5 @@ describe 'integer parameter constraints' do
   rejects 'abc'
   rejects Date.today
   rejects Time.now
+  rejects nil
 end

--- a/test/map_constraints_test.rb
+++ b/test/map_constraints_test.rb
@@ -25,6 +25,7 @@ describe 'map parameter constraints' do
   rejects(:id => 'Mick', :name => 'Mick')
   rejects(123)
   rejects('abc')
+  rejects nil
 end
 
 describe 'open-ended map parameter constraints' do
@@ -44,4 +45,5 @@ describe 'open-ended map parameter constraints' do
   permits({:id => 1, :name => 'Mick'})
   rejects("a string")
   rejects(123)
+  rejects nil
 end

--- a/test/operator_constraints_test.rb
+++ b/test/operator_constraints_test.rb
@@ -9,6 +9,7 @@ describe 'operator parameter constraints' do
 
     rejects Date.today
     rejects Time.now
+    rejects nil
   end
 
   describe 'AND types' do
@@ -18,5 +19,6 @@ describe 'operator parameter constraints' do
 
     rejects 123
     rejects 'abc'
+    rejects nil
   end
 end

--- a/test/string_constraints_test.rb
+++ b/test/string_constraints_test.rb
@@ -8,6 +8,7 @@ describe 'string parameter constraints' do
   rejects 123
   rejects Date.today
   rejects Time.now
+  rejects nil
 
   it 'rejects strings that are too long' do
     assert_rejects(:value) { params(:value => '123').permit(:value => ActionController::Parameters.string(:max_length => 2)) }


### PR DESCRIPTION
As described here: https://github.com/zendesk/stronger_parameters/issues/4

Now if there are any constraints on a param, then nil value will always raise an exception.