### PR TITLE
flag to allow nils

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
  - added new `Parameters.regexp`
  - added new `Parameters.null_string`
  - added new unsigned `Parameters.ubigid` and `Parameters.uid`
- - WARNING: no longer accepts `nil` for all parameters, use ` | Parameters.nil`, for transition period you can use this to log all calls that would result in `StrongerParameters::InvalidParameter`
+ - WARNING: no longer accepts `nil` for all parameters, use ` | Parameters.nil`, for transition period you can use this to log all calls that would result in `StrongerParameters::InvalidParameter`, alternatively keep nils and use `ActionController::Parameters.allow_nil_for_everything = true`
  - `action_on_invalid_parameters` will now raise by default
  - `action_on_invalid_parameters` is now set on `ActionController::Parameters`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ This will allow an array of id parameters that all are IDs (integer less than 2*
 Rails converts empty arrays to nil unless `config.action_dispatch.perform_deep_munge = false` is set
 (available in Rails 4.1+). Either use this or `Parameters.array | Parameters.nil` to deal with this.
 
+### Allowing nils
+
+It can be convenient to allow nil to be passed as all kinds of attributes since ActiveRecord converts it to false/0 behind the scenes.
+`ActionController::Parameters.allow_nil_for_everything = true`
+
 ## Nested Parameters
 
 ```ruby

--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -16,6 +16,7 @@ module StrongerParameters
     included do
       alias_method_chain :hash_filter, :stronger_parameters
       cattr_accessor :action_on_invalid_parameters, :instance_accessor => false
+      cattr_accessor :allow_nil_for_everything, :instance_accessor => false
     end
 
     module ClassMethods
@@ -120,6 +121,11 @@ module StrongerParameters
       hash_filter_without_stronger_parameters(params, other_filter)
 
       slice(*stronger_filter.keys).each do |key, value|
+        if value.nil? && self.class.allow_nil_for_everything
+          params[key] = nil
+          next
+        end
+
         constraint = stronger_filter[key]
         result = constraint.value(value)
         if result.is_a?(InvalidValue)

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -159,8 +159,29 @@ describe StrongerParameters::Parameters do
       end
     end
 
-    it "passes with nil for non-constraints" do
-      params(:value => nil).permit(:value => [{:key => ActionController::Parameters.integer32}]).must_equal({})
+    describe "nils" do
+      def pass_nil_as_constrain
+        params(:value => nil).permit(:value => ActionController::Parameters.integer32)
+      end
+
+      it "passes with nil for non-constraints" do
+        params(:value => nil).permit(:value => [{:key => ActionController::Parameters.integer32}])
+      end
+
+      it "does not pass with nil for constraints" do
+        assert_raises StrongerParameters::InvalidParameter do
+          pass_nil_as_constrain
+        end
+      end
+
+      it "passes with nil for constraints when allow_nil_for_everything is on" do
+        begin
+          old, ActionController::Parameters.allow_nil_for_everything = ActionController::Parameters.allow_nil_for_everything, true
+          pass_nil_as_constrain.must_equal("value" => nil)
+        ensure
+          ActionController::Parameters.allow_nil_for_everything = old
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
passing in nils is not an issue most of the time since rails converts them to 0/false/etc when storing,
so they are technically not correct but are the default in the db anyway + often submitted by api users

@zendesk/octo 
