### PR TITLE
Fail date constraint on TypeError

### DIFF
--- a/lib/stronger_parameters/constraints/date_time_constraint.rb
+++ b/lib/stronger_parameters/constraints/date_time_constraint.rb
@@ -7,7 +7,7 @@ module StrongerParameters
 
       begin
         DateTime.parse v
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         StrongerParameters::InvalidValue.new(v, "must be a date")
       end
     end

--- a/test/date_constraint_test.rb
+++ b/test/date_constraint_test.rb
@@ -6,6 +6,9 @@ describe 'date parameter constraints' do
   permits "2015-03-31", as: DateTime.parse("2015-03-31")
   permits "2015-03-31T14:34:56Z", as: DateTime.parse("2015-03-31T14:34:56Z")
 
+  rejects []
+  rejects 123
+  rejects nil
   rejects "2015-03-32"  # Invalid day
   rejects "2015-00-15"  # Invalid month
 end


### PR DESCRIPTION
DateTime.parse also throws TypeError when given non-string input. This fix catches TypeError so the correct error is returned.