### PR TITLE
Fixes #26

### DIFF
--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -3,6 +3,7 @@ require 'action_pack'
 if ActionPack::VERSION::MAJOR == 3
   require 'action_controller/parameters'
 else
+  require 'action_controller/base'
   require 'action_controller/metal/strong_parameters'
 end
 


### PR DESCRIPTION
This fixes an issue with Rails 4 as `ActionController::Base` is not required by actionpack explicitly anymore.

@grosser Please review.