### PR TITLE
allow the value "on" to be considered boolean

### DIFF
--- a/lib/stronger_parameters/constraints/boolean_constraint.rb
+++ b/lib/stronger_parameters/constraints/boolean_constraint.rb
@@ -2,7 +2,7 @@ require 'stronger_parameters/constraints'
 
 module StrongerParameters
   class BooleanConstraint < Constraint
-    TRUE_VALUES  = [true, 'true', '1', 1].freeze
+    TRUE_VALUES  = [true, 'true', '1', 1, 'on'].freeze
     FALSE_VALUES = [false, 'false', '0', 0].freeze
 
     def value(v)

--- a/test/boolean_constraints_test.rb
+++ b/test/boolean_constraints_test.rb
@@ -7,6 +7,7 @@ describe 'boolean parameter constraints' do
   permits 'true', :as => true
   permits 1,      :as => true
   permits '1',    :as => true
+  permits 'on',    :as => true
 
   permits false,   :as => false
   permits 'false', :as => false


### PR DESCRIPTION
:koala:

The default value sent by a HTML checkbox in a form is 'on'. Should that work out of the box?

@staugaard @grosser 

/cc @zendesk/quokka
