### PR TITLE
Fix typo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@
  - added new `Parameters.nil`
  - added new `Parameters.float`
  - added new `Parameters.regexp`
- - added new `Parameters.null_string`
+ - added new `Parameters.nil_string`
  - added new unsigned `Parameters.ubigid` and `Parameters.uid`
  - WARNING: no longer accepts `nil` for all parameters, use ` | Parameters.nil`, for transition period you can use this to log all calls that would result in `StrongerParameters::InvalidParameter`, alternatively keep nils and use `ActionController::Parameters.allow_nil_for_everything = true`
  - `action_on_invalid_parameters` will now raise by default


### PR DESCRIPTION
Fix typo: `null_string` => `nil_string`