### PR TITLE
Compatibility with Rails 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.8
   - 2.2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
 before_install: gem install bundler
 gemfile:
   - gemfiles/rails3.2.gemfile
-  - gemfiles/rails4.0.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,14 @@ gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
+  - gemfiles/rails5.0.gemfile
 branches:
   only: master
 script: bundle exec rake test
 matrix:
   fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails5.0.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails5.0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.1.8
   - 2.2.3
   - 2.3.0
-before_install: gem install bundler
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.1.gemfile

--- a/gemfiles/rails4.0.gemfile
+++ b/gemfiles/rails4.0.gemfile
@@ -1,3 +1,0 @@
-gem "rails", "~> 4.0.13"
-
-eval_gemfile 'gemfiles/common.rb'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,0 +1,4 @@
+gem "rails", "~> 5.0.0.beta1"
+gem "minitest-rails", github: "pschambacher/minitest-rails", ref: "b3586d0"
+
+eval_gemfile 'gemfiles/common.rb'

--- a/lib/stronger_parameters/constraints/hash_constraint.rb
+++ b/lib/stronger_parameters/constraints/hash_constraint.rb
@@ -9,9 +9,13 @@ module StrongerParameters
     end
 
     def value(v)
-      if v.is_a?(Hash)
+      case
+      when v.is_a?(Hash)
         return ActionController::Parameters.new(v).permit! if constraints.nil?
         return ActionController::Parameters.new(v).permit(constraints)
+      when ActionPack::VERSION::MAJOR >= 5 && v.is_a?(ActionController::Parameters)
+        return v.permit! if constraints.nil?
+        return v.permit(constraints)
       end
 
       InvalidValue.new(v, "must be a hash")

--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -15,7 +15,8 @@ module StrongerParameters
     extend ActiveSupport::Concern
 
     included do
-      alias_method_chain :hash_filter, :stronger_parameters
+      alias_method :hash_filter_without_stronger_parameters, :hash_filter
+      alias_method :hash_filter, :hash_filter_with_stronger_parameters
       cattr_accessor :action_on_invalid_parameters, :instance_accessor => false
       cattr_accessor :allow_nil_for_everything, :instance_accessor => false
     end
@@ -172,7 +173,7 @@ module StrongerParameters
 
     included do
       rescue_from(StrongerParameters::InvalidParameter) do |e|
-        render :text => "Invalid parameter: #{e.key} #{e.message}", :status => :bad_request
+        render (ActiveSupport::VERSION::MAJOR < 5 ? :text : :plain) => "Invalid parameter: #{e.key} #{e.message}", :status => :bad_request
       end
     end
   end

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'wwtd'
   spec.add_development_dependency 'bump'
 
-  spec.add_runtime_dependency 'actionpack', '> 3'
+  spec.add_runtime_dependency 'actionpack', '>= 3.2', '< 5.1'
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -10,17 +10,29 @@ end
 
 describe BooksController do
   it 'rejects invalid params' do
-    post :create, { :magazine => { :name => 'Mjallo!' } }
+    if Rails::VERSION::MAJOR < 5
+      post :create, { :magazine => { :name => 'Mjallo!' } }
+    else
+      post :create, :params => { :magazine => { :name => 'Mjallo!' } }
+    end
     assert_response :bad_request
     response.body.must_equal 'Required parameter missing: book'
 
-    post :create, { :book => { :id => 'Mjallo!' } }
+    if Rails::VERSION::MAJOR < 5
+      post :create, { :book => { :id => 'Mjallo!' } }
+    else
+      post :create, :params => { :book => { :id => 'Mjallo!' } }
+    end
     assert_response :bad_request
     response.body.must_equal 'Invalid parameter: id must be an integer'
   end
 
   it 'permits valid params' do
-    post :create, { :book => { :id => '123' } }
+    if Rails::VERSION::MAJOR < 5
+      post :create, { :book => { :id => '123' } }
+    else
+      post :create, :params => { :book => { :id => '123' } }
+    end
     assert_response :ok
   end
 end

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -95,7 +95,7 @@ describe StrongerParameters::Parameters do
     it "calls a block on mismatch" do
       calls = []
       ActionController::Parameters.action_on_invalid_parameters = lambda { |*args| calls << args }
-      result = params(:value => "a").permit(:value => ActionController::Parameters.integer32)
+      result = params(:value => "a").permit(:value => ActionController::Parameters.integer32).to_h
       calls.size.must_equal 1
       calls[0].size.must_equal 2
       calls[0][0].value.must_equal "a"
@@ -107,7 +107,7 @@ describe StrongerParameters::Parameters do
     it "logs on log" do
       ActionController::Parameters.action_on_invalid_parameters = :log
       log = capture_log do
-        result = params(:value => "a").permit(:value => ActionController::Parameters.integer32)
+        result = params(:value => "a").permit(:value => ActionController::Parameters.integer32).to_h
         result.must_equal "value" => "a"
       end
       log.must_include "value must be an integer, but was: \"a\""
@@ -136,21 +136,21 @@ describe StrongerParameters::Parameters do
 
   describe "mixing non constraints" do
     it "passes normal" do
-      params(:foo => "b", :value => "a").permit(:value).must_equal "value" => "a"
+      params(:foo => "b", :value => "a").permit(:value).to_h.must_equal "value" => "a"
     end
 
     it "passes nested constraints in non-constraint" do
-      params(:value => {:key => 123}).permit(:value => {:key => ActionController::Parameters.integer32}).must_equal "value" => {"key" => 123}
+      params(:value => {:key => 123}).permit(:value => {:key => ActionController::Parameters.integer32}).to_h.must_equal "value" => {"key" => 123}
     end
 
     it "fails nested constraints in non-constraint" do
       assert_raises StrongerParameters::InvalidParameter do
-        params(:value => {:key => "xxx"}).permit(:value => {:key => ActionController::Parameters.integer32})
+        params(:value => {:key => "xxx"}).permit(:value => {:key => ActionController::Parameters.integer32}).to_h
       end
     end
 
     it "passes nested constraints in non-constraint array" do
-      params(:value => [{:key => 123}]).permit(:value => [{:key => ActionController::Parameters.integer32}]).must_equal "value" => [{"key" => 123}]
+      params(:value => [{:key => 123}]).permit(:value => [{:key => ActionController::Parameters.integer32}]).to_h.must_equal "value" => [{"key" => 123}]
     end
 
     it "fails nested constraints in non-constraint array" do
@@ -177,7 +177,7 @@ describe StrongerParameters::Parameters do
       it "passes with nil for constraints when allow_nil_for_everything is on" do
         begin
           old, ActionController::Parameters.allow_nil_for_everything = ActionController::Parameters.allow_nil_for_everything, true
-          pass_nil_as_constrain.must_equal("value" => nil)
+          pass_nil_as_constrain.to_h.must_equal("value" => nil)
         ensure
           ActionController::Parameters.allow_nil_for_everything = old
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ module ActionController
     include SharedTestRoutes.url_helpers
 
     rescue_from(ActionController::ParameterMissing) do |e|
-      render :text => "Required parameter missing: #{e.param}", :status => :bad_request
+      render (ActiveSupport::VERSION::MAJOR < 5 ? :text : :plain) => "Required parameter missing: #{e.param}", :status => :bad_request
     end
   end
 
@@ -63,6 +63,7 @@ class MiniTest::Spec
 
     it "permits #{value.inspect} as #{type_casted.inspect}" do
       permitted = params(:value => value).permit(:value => subject)
+      permitted = permitted.to_h if Rails::VERSION::MAJOR >= 5
       permitted[:value].must_equal type_casted
     end
   end


### PR DESCRIPTION
:octopus::computer:

/cc @bquorning @grosser 

### Description
Most of the fight was due to the fact that `ActionController::Parameters` doesn't inherit from `Hash` anymore.

### Steps to merge
* [ ] :+1: from the team

### Risks
* None (behind version guard)