### PR TITLE
validating rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
+  - gemfiles/rails5.1.gemfile
 branches:
   only: master
 script: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ matrix:
       gemfile: gemfiles/rails5.0.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails5.0.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails5.1.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails5.1.gemfile

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,0 +1,4 @@
+gem "rails", "~> 5.1.0"
+gem "rails-controller-testing"
+
+eval_gemfile 'gemfiles/common.rb'

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'wwtd'
   spec.add_development_dependency 'bump'
 
-  spec.add_runtime_dependency 'actionpack', '>= 3.2', '< 5.1'
+  spec.add_runtime_dependency 'actionpack', '>= 3.2'
 end

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'wwtd'
   spec.add_development_dependency 'bump'
 
-  spec.add_runtime_dependency 'actionpack', '>= 3.2'
+  spec.add_runtime_dependency 'actionpack', '>= 3.2', '< 5.2'
 end


### PR DESCRIPTION
This PR validates rails 5.1 version. I removed as well the upper boundary on actionpack. Below are my thoughts about that.
I would personally not set an upper bound on rails version unless a real problem is known. rails upgrade is a big thing in itself and everyone is doing this usually responsibly. It would make it easier for everyone to try new rails version as soon as it is out. Nobody expects a promise on future compatibility and nobody will hold you responsible for breakage.