### PR TITLE
Add key to error message

### DIFF
--- a/lib/stronger_parameters/errors.rb
+++ b/lib/stronger_parameters/errors.rb
@@ -14,7 +14,7 @@ module StrongerParameters
     def initialize(invalid_value, key)
       @value = invalid_value.value
       @key = key
-      super(invalid_value.message)
+      super("Invalid parameter: #{@key} #{invalid_value.message}")
     end
   end
 end

--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -177,7 +177,7 @@ module StrongerParameters
 
     included do
       rescue_from(StrongerParameters::InvalidParameter) do |e|
-        render (ActiveSupport::VERSION::MAJOR < 5 ? :text : :plain) => "Invalid parameter: #{e.key} #{e.message}", :status => :bad_request
+        render (ActiveSupport::VERSION::MAJOR < 5 ? :text : :plain) => e.message, :status => :bad_request
       end
     end
   end


### PR DESCRIPTION
The error message is currently in two places: the controller
`rescue_from`, and the actual error message. This makes sure both throw
the same error message, and the key (attribute that failed) is present
in that message.

See https://github.com/zendesk/stronger_parameters/pull/39