### PR TITLE
remove hash inheritance

### DIFF
--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'wwtd'
   spec.add_development_dependency 'bump'
+  spec.add_development_dependency 'single_cov'
 
   spec.add_runtime_dependency 'actionpack', '>= 3.2', '< 5.2'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
 ENV["RAILS_ENV"] = "test"
 
 require 'bundler/setup'
+
+require 'single_cov'
+SingleCov.setup :minitest
+
 require 'minitest/autorun'
 require 'minitest/rg'
 require 'minitest/around'
@@ -13,6 +17,7 @@ class FakeApplication < Rails::Application; end
 Rails.application = FakeApplication
 Rails.configuration.action_controller = ActiveSupport::OrderedOptions.new
 Rails.configuration.secret_key_base = 'secret_key_base'
+Rails.logger = Logger.new("/dev/null")
 
 ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
 


### PR DESCRIPTION
tried to keep it objectiy but things got too confusing ... Hash / PermittedParametersHash / HashConstraint all mashed into one ... was not fun ... so it's static now ...