### PR TITLE
silence route warnings and localize global hacks

### DIFF
--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -3,6 +3,15 @@ require_relative 'test_helper'
 SingleCov.not_covered!
 
 class BooksController < ActionController::Base
+  ROUTES = ActionDispatch::Routing::RouteSet.new
+  ROUTES.draw { resources :books }
+  include ROUTES.url_helpers
+
+  rescue_from(ActionController::ParameterMissing) do |e|
+    type = (ActiveSupport::VERSION::MAJOR < 5 ? :text : :plain)
+    render type => "Required parameter missing: #{e.param}", :status => :bad_request
+  end
+
   def create
     params.require(:book).permit(:id => Parameters.integer)
 
@@ -11,30 +20,28 @@ class BooksController < ActionController::Base
 end
 
 describe BooksController do
-  it 'rejects invalid params' do
+  def post(action, options = {})
     if Rails::VERSION::MAJOR < 5
-      post :create, { :magazine => { :name => 'Mjallo!' } }
+      super(action, options.fetch(:params))
     else
-      post :create, :params => { :magazine => { :name => 'Mjallo!' } }
+      super
     end
+  end
+
+  before { @routes = BooksController::ROUTES }
+
+  it 'rejects invalid params' do
+    post :create, params: {magazine: {name: 'Mjallo!'}}
     assert_response :bad_request
     response.body.must_equal 'Required parameter missing: book'
 
-    if Rails::VERSION::MAJOR < 5
-      post :create, { :book => { :id => 'Mjallo!' } }
-    else
-      post :create, :params => { :book => { :id => 'Mjallo!' } }
-    end
+    post :create, params: {book: {id: 'Mjallo!'}}
     assert_response :bad_request
     response.body.must_equal 'Invalid parameter: id must be an integer'
   end
 
   it 'permits valid params' do
-    if Rails::VERSION::MAJOR < 5
-      post :create, { :book => { :id => '123' } }
-    else
-      post :create, :params => { :book => { :id => '123' } }
-    end
+    post :create, params: {book: {id: '123'}}
     assert_response :ok
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,32 +23,6 @@ ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
 
 require 'action_pack'
 require 'strong_parameters' if ActionPack::VERSION::MAJOR == 3
-
-module ActionController
-  SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
-  SharedTestRoutes.draw do
-    get ':controller(/:action)'
-    post ':controller(/:action)'
-    put ':controller(/:action)'
-    delete ':controller(/:action)'
-  end
-
-  class Base
-    include ActionController::Testing
-    include SharedTestRoutes.url_helpers
-
-    rescue_from(ActionController::ParameterMissing) do |e|
-      render (ActiveSupport::VERSION::MAJOR < 5 ? :text : :plain) => "Required parameter missing: #{e.param}", :status => :bad_request
-    end
-  end
-
-  class ActionController::TestCase
-    setup do
-      @routes = SharedTestRoutes
-    end
-  end
-end
-
 require 'stronger_parameters'
 require 'minitest/rails'
 require 'minitest/autorun'


### PR DESCRIPTION
DEPRECATION WARNING: Using a dynamic :controller segment in a route is deprecated and will be removed in Rails 5.2.