### PR TITLE
Raise proper exception if action is not defined (and not configured)

### DIFF
--- a/lib/stronger_parameters/controller_support/permitted_parameters.rb
+++ b/lib/stronger_parameters/controller_support/permitted_parameters.rb
@@ -54,11 +54,10 @@ module StrongerParameters
 
         def permitted_parameters_for(action)
           unless for_action = permit_parameters[action]
-            location = instance_method(action).source_location
-            raise(
-              KeyError,
-              "Action #{action} for #{self} does not have any permitted parameters (#{location.join(":")})"
-            )
+            message = "Action #{action} for #{self} does not have any permitted parameters"
+            message += " (#{instance_method(action).source_location.join(":")})" if method_defined?(action)
+
+            raise(KeyError, message)
           end
           return :skip if for_action == :skip
 

--- a/lib/stronger_parameters/controller_support/permitted_parameters.rb
+++ b/lib/stronger_parameters/controller_support/permitted_parameters.rb
@@ -54,9 +54,10 @@ module StrongerParameters
 
         def permitted_parameters_for(action)
           unless for_action = permit_parameters[action]
+            # NOTE: there is no easy way to test this, so make sure to test with
+            # a real rails controller if you make changes.
             message = "Action #{action} for #{self} does not have any permitted parameters"
             message += " (#{instance_method(action).source_location.join(":")})" if method_defined?(action)
-
             raise(KeyError, message)
           end
           return :skip if for_action == :skip

--- a/test/stronger_parameters/controller_support/permitted_parameters_test.rb
+++ b/test/stronger_parameters/controller_support/permitted_parameters_test.rb
@@ -185,6 +185,11 @@ describe WhitelistsController do
       assert_raises(KeyError) { get :show, params: {id: 1} }
     end
 
+    it 'raises proper exception even if action is not defined (and not configured)' do
+      @controller.params.merge!(action: 'ops_not_here', id: 1)
+      assert_raises(KeyError) { @controller.send(:permit_parameters) }
+    end
+
     it 'overrides :skip' do
       WhitelistsController.permitted_parameters :index, :skip
       WhitelistsController.permitted_parameters :index, bar: Parameters.boolean


### PR DESCRIPTION
/cc @grosser @zendesk/i18n-dev @miketineo 