### PR TITLE
change Parameters.anything to Parameters.string in default to fix rails5.1 compatibility

### DIFF
--- a/lib/stronger_parameters/controller_support/permitted_parameters.rb
+++ b/lib/stronger_parameters/controller_support/permitted_parameters.rb
@@ -25,9 +25,9 @@ module StrongerParameters
       end
 
       DEFAULT_PERMITTED = {
-        controller: ActionController::Parameters.anything,
-        action: ActionController::Parameters.anything,
-        format: ActionController::Parameters.anything,
+        controller: ActionController::Parameters.string,
+        action: ActionController::Parameters.string,
+        format: ActionController::Parameters.string,
         authenticity_token: ActionController::Parameters.string,
         utf8: Parameters.string,
         _method: Parameters.string,


### PR DESCRIPTION
@zendesk/secdev @pschambacher 

## Description
Found issue with Parameters.anything when trying to use in rails 5.1  service. 
The default controller, action and format appear to be strings so I made this specific.

## Risks
low 
Rollback if this causes issues.