### PR TITLE
implement "required" parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v2.9.0
+
+- allow parameters to be marked as required (refs GH#72)
+
 # v2.8.0
 - Controller support (PermittedParameters)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ Rails converts empty arrays to nil, so often `Parameters.array | Parameters.nil`
 It can be convenient to allow nil for all attributes since ActiveRecord converts it to false/0.
 `ActionController::Parameters.allow_nil_for_everything = true`
 
+### Rejecting nils
+
+You can reject a request that fails to supply certain parameters by marking them
+as required with the `.required` operator:
+
+```ruby
+params.permit(
+  name: Parameters.string.required, # will not accept a nil or a non-String
+  email: Parameters.string          # optional, may be omitted
+)
+```
+
+This also works in conjunction with the `&` and `|` constraints. For example, to
+express that a `uid` must be either a string or a number:
+
+```ruby
+params.permit(
+  uid: (Parameters.string | Parameters.integer).required
+)
+```
+
 ## Nested Parameters
 
 ```ruby

--- a/lib/stronger_parameters/constraint.rb
+++ b/lib/stronger_parameters/constraint.rb
@@ -18,6 +18,14 @@ module StrongerParameters
     def ==(other)
       self.class == other.class
     end
+
+    def required
+      RequiredConstraint.new(self)
+    end
+
+    def required?
+      false
+    end
   end
 
   class OrConstraint < Constraint
@@ -50,6 +58,10 @@ module StrongerParameters
     def ==(other)
       super && constraints == other.constraints
     end
+
+    def required?
+      constraints.all?(&:required?)
+    end
   end
 
   class AndConstraint < Constraint
@@ -74,6 +86,24 @@ module StrongerParameters
 
     def ==(other)
       super && constraints == other.constraints
+    end
+
+    def required?
+      constraints.any?(&:required?)
+    end
+  end
+
+  class RequiredConstraint < Constraint
+    def initialize(other)
+      @other = other
+    end
+
+    def value(v)
+      @other.value(v)
+    end
+
+    def required?
+      true
     end
   end
 end

--- a/test/stronger_parameters/constraint_test.rb
+++ b/test/stronger_parameters/constraint_test.rb
@@ -23,6 +23,12 @@ describe StrongerParameters::Constraint do
       subject.wont_equal StrongerParameters::OrConstraint.new
     end
   end
+
+  describe "#required?" do
+    it "is false by default" do
+      subject.required?.must_equal(false)
+    end
+  end
 end
 
 describe StrongerParameters::OrConstraint do
@@ -57,6 +63,26 @@ describe StrongerParameters::OrConstraint do
       subject.wont_equal(ActionController::Parameters.string & ActionController::Parameters.integer)
     end
   end
+
+  describe "#required?" do
+    it "is true if all of the constraints are required" do
+      subject = (
+        ActionController::Parameters.string.required |
+        ActionController::Parameters.integer.required
+      )
+
+      subject.required?.must_equal(true)
+    end
+
+    it "is false if one of the constrants is not required" do
+      subject = (
+        ActionController::Parameters.string.required |
+        ActionController::Parameters.integer
+      )
+
+      subject.required?.must_equal(false)
+    end
+  end
 end
 
 describe StrongerParameters::AndConstraint do
@@ -89,4 +115,31 @@ describe StrongerParameters::AndConstraint do
       subject.wont_equal(ActionController::Parameters.integer & ActionController::Parameters.string)
     end
   end
+
+  describe "#required?" do
+    it "is true if any of the constraints is required" do
+      subject = (
+        ActionController::Parameters.string.required &
+        ActionController::Parameters.integer
+      )
+
+      subject.required?.must_equal(true)
+    end
+
+    it "is false if none of the constrants are required" do
+      subject = (
+        ActionController::Parameters.string &
+        ActionController::Parameters.integer
+      )
+
+      subject.required?.must_equal(false)
+    end
+  end
+end
+
+describe StrongerParameters::RequiredConstraint do
+  subject { ActionController::Parameters.string.required }
+
+  rejects nil
+  permits '123'
 end

--- a/test/stronger_parameters/parameters_test.rb
+++ b/test/stronger_parameters/parameters_test.rb
@@ -280,6 +280,16 @@ describe StrongerParameters::Parameters do
       end
     end
 
+    describe "requireds" do
+      it "does not pass if a required parameter is not supplied" do
+        error = assert_raises StrongerParameters::InvalidParameter do
+          params({}).permit(value: ActionController::Parameters.string.required)
+        end
+
+        assert_match("value must be present", error.message)
+      end
+    end
+
     describe "nils" do
       def pass_nil_as_constrain
         params(value: nil).permit(value: ActionController::Parameters.integer32)


### PR DESCRIPTION
allow for parameters to be marked "required" so that we raise an error
when the user supplies no value for them

behavior with modifier constraints:

- OrConstraint is required if _all_ of the constraints are required:

```ruby
P.string.required | P.datetime.required # => true
```

- OrConstraint is required if it itself was marked required:

```ruby
(P.string | P.date).required            # => true
```

- AndConstraint is required if _any_ of the constraints is required:

```ruby
P.integer.required & P.gt(0)            # => true
P.integer.required & P.gt(0).required   # => true
```

- AndConstraint is required if it itself was marked required:

```ruby
(P.integer & P.gt(0)).required          # => true
```

example usage:

```ruby
params.permit(
  user: P.map(
    name: P.string,
    email: P.string.required,
    birthdate: P.string.required | P.datetime.required,
  )
)
```