### PR TITLE
Add Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ gemfile:
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
 branches:
   only: master
 before_install: gem install bundler --no-ri --no-rdoc

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+gem "rails", "~> 6.0.0.rc1"
+gem "rails-controller-testing"
+
+eval_gemfile 'common.rb'

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'mocha'
 
-  spec.add_runtime_dependency 'actionpack', '>= 3.2', '< 5.3'
+  spec.add_runtime_dependency 'actionpack', '>= 3.2', '< 6.1'
 
   spec.required_ruby_version = '>= 2.2.0'
 end


### PR DESCRIPTION
This adds base support and test case on travis for Rails `6.0.0.rc1` This fixes #73 