### PR TITLE
Missing parameters set to nil

### DIFF
--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -147,8 +147,8 @@ module StrongerParameters
         value = fetch(key, nil)
         result = nil
 
-        if key?(key) && value.nil? && self.class.allow_nil_for_everything
-          params[key] = nil
+        if value.nil? && self.class.allow_nil_for_everything
+          params[key] = nil if key?(key)
           next
         end
 

--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -147,7 +147,7 @@ module StrongerParameters
         value = fetch(key, nil)
         result = nil
 
-        if value.nil? && self.class.allow_nil_for_everything
+        if key?(key) && value.nil? && self.class.allow_nil_for_everything
           params[key] = nil
           next
         end

--- a/test/stronger_parameters/parameters_test.rb
+++ b/test/stronger_parameters/parameters_test.rb
@@ -314,6 +314,16 @@ describe StrongerParameters::Parameters do
           ActionController::Parameters.allow_nil_for_everything = old
         end
       end
+
+      it "does not create keys if parameter is not supplied and allow_nil_for_everything is on" do
+        begin
+          old = ActionController::Parameters.allow_nil_for_everything
+          ActionController::Parameters.allow_nil_for_everything = true
+          params({}).permit(value: ActionController::Parameters.string).to_h.must_equal({})
+        ensure
+          ActionController::Parameters.allow_nil_for_everything = old
+        end
+      end
     end
   end
 end

--- a/test/stronger_parameters/parameters_test.rb
+++ b/test/stronger_parameters/parameters_test.rb
@@ -295,6 +295,14 @@ describe StrongerParameters::Parameters do
         params(value: nil).permit(value: ActionController::Parameters.integer32)
       end
 
+      def with_allow_nil_for_everything(value = true)
+        old = ActionController::Parameters.allow_nil_for_everything
+        ActionController::Parameters.allow_nil_for_everything = value
+        yield
+      ensure
+        ActionController::Parameters.allow_nil_for_everything = old
+      end
+
       it "passes with nil for non-constraints" do
         params(value: nil).permit(value: [{key: ActionController::Parameters.integer32}])
       end
@@ -306,22 +314,14 @@ describe StrongerParameters::Parameters do
       end
 
       it "passes with nil for constraints when allow_nil_for_everything is on" do
-        begin
-          old = ActionController::Parameters.allow_nil_for_everything
-          ActionController::Parameters.allow_nil_for_everything = true
+        with_allow_nil_for_everything do
           pass_nil_as_constrain.to_h.must_equal("value" => nil)
-        ensure
-          ActionController::Parameters.allow_nil_for_everything = old
         end
       end
 
       it "does not create keys if parameter is not supplied and allow_nil_for_everything is on" do
-        begin
-          old = ActionController::Parameters.allow_nil_for_everything
-          ActionController::Parameters.allow_nil_for_everything = true
+        with_allow_nil_for_everything do
           params({}).permit(value: ActionController::Parameters.string).to_h.must_equal({})
-        ensure
-          ActionController::Parameters.allow_nil_for_everything = old
         end
       end
     end


### PR DESCRIPTION
Looks like in v1.12.0 with `allow_nil_for_everything = true` all permitted parameters are set to `nil` if they're not provided. This makes partial updating difficult since all AR attributes are getting nullified. I'm providing a failing spec and a proposed solution to fix the problem. 