### PR TITLE
[R5U-2431] Addresses customers inputing strings of numbers with leading whitespace

### DIFF
--- a/lib/stronger_parameters/constraints/integer_constraint.rb
+++ b/lib/stronger_parameters/constraints/integer_constraint.rb
@@ -6,7 +6,7 @@ module StrongerParameters
     def value(v)
       if v.is_a?(Integer)
         return v
-      elsif v.is_a?(String) && v =~ /\A-?\d+\Z/
+      elsif v.is_a?(String) && v.strip =~ /\A-?\d+\Z/
         return v.to_i
       end
 

--- a/test/stronger_parameters/constraints/integer_constraint_test.rb
+++ b/test/stronger_parameters/constraints/integer_constraint_test.rb
@@ -10,9 +10,11 @@ describe 'integer parameter constraints' do
   permits 2**64
   permits '123', as: 123
   permits '-123', as: -123
+  permits ' 123', as: 123
 
   rejects 'abc'
   rejects Date.today
   rejects Time.now
   rejects nil
+  rejects '   '
 end


### PR DESCRIPTION
The Rails Upgrade Team has identified customers submitting strings of numbers with leading space to various endpoints.  This sets us up to allow for the leading whitespace.  

Example:
Invalid parameter {:key=>"ticket.requester_id", :value=>" 1901886919004", :message=>"must be an integer"} ~[link to logs](https://zendesk.datadoghq.com/logs?cols=&context_event=AQAAAXzi-QdrgHMdSAAAAABBWHppLVQ3cEFBQm9JYjM2MnJwc3JnRVc&event=&from_ts=1635895258159&index=&live=false&messageDisplay=inline&query=host%3Ai-0fc5431ca8633c0e9+service%3Aclassic+container_id%3Ad31e5c92a8a7cba1d33da61cb89b83dd18af219a53535502144bef331eebca1a&saved_view&stream_sort=desc&to_event=AQAAAXzi-RAEIwhyogAAAABBWHppLVQzeUFBQklsQjBzaXpvTjhnRS0&to_ts=1635895545860&viz=)