### PR TITLE
Allow boolean string values of any casing (eg "TRUE")

### DIFF
--- a/lib/stronger_parameters/constraints/boolean_constraint.rb
+++ b/lib/stronger_parameters/constraints/boolean_constraint.rb
@@ -7,6 +7,8 @@ module StrongerParameters
     FALSE_VALUES = [false, 'false', '0', 0].freeze
 
     def value(v)
+      v = v.downcase if v.is_a? String
+
       return true if TRUE_VALUES.include?(v)
 
       return false if FALSE_VALUES.include?(v)

--- a/test/stronger_parameters/constraints/boolean_constraint_test.rb
+++ b/test/stronger_parameters/constraints/boolean_constraint_test.rb
@@ -8,12 +8,14 @@ describe 'boolean parameter constraints' do
 
   permits true,    as: true
   permits 'true',  as: true
+  permits 'True',  as: true
   permits 1,       as: true
   permits '1',     as: true
   permits 'on',    as: true
 
   permits false,   as: false
   permits 'false', as: false
+  permits 'FALSE', as: false
   permits 0,       as: false
   permits '0',     as: false
 


### PR DESCRIPTION
This came about because we're getting `ticket.requester.verified:
"True"` and it should probably be flexible enough to allow for that.