### PR TITLE
Backfills changelog info for 2.17.0 and 2.19.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,18 @@
 # 2.20.0
 - Adds a ULID constraint type
 
+# 2.19.1
+- Error string correction in Datetime constraint
+- Adds support for date, date_iso8601, time, and time_iso8601 constraints
+- Changes ActiveSupport::Notifications.publish -> ActiveSupport::Notifications.instrument
+- CI automations
+
+# 2.17.0
+- Support for rails in API-only mode
+- Drop ruby 2.5 and 2.6 support
+- Add ruby 3.0 and 3.1 support
+- Add rails 7.0 support
+
 # v2.16.0
 - rails 7 support
 - rails 4 removed


### PR DESCRIPTION
There are a couple intermediate tags, but 2.17.0 and 2.19.1 are the only ones published as gems, so I bucketed changes under those. 