### PR TITLE
Test without forking_test_runner

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,8 +92,6 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -136,8 +134,6 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
-    parallel_tests (4.3.0)
-      parallel
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -224,7 +220,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest (~> 5.20)
   minitest-rails (~> 7.1)

--- a/Rakefile
+++ b/Rakefile
@@ -2,15 +2,18 @@
 require 'bundler/setup'
 require 'bump/tasks'
 
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
+end
+
 # Pushing to rubygems is handled by a github workflow
 require 'bundler/gem_tasks'
 ENV['gem_push'] = 'false'
 
 task default: [:test, :rubocop]
-
-task :test do
-  sh "forking-test-runner test --merge-coverage --quiet"
-end
 
 desc "Run rubocop"
 task :rubocop do

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -52,8 +52,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubis (2.7.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -92,8 +90,6 @@ GEM
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     racc (1.6.2)
@@ -165,7 +161,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 5.0.0)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -52,8 +52,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -92,8 +90,6 @@ GEM
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     racc (1.6.2)
@@ -165,7 +161,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 5.1.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -56,8 +56,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -97,8 +95,6 @@ GEM
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     racc (1.6.2)
@@ -171,7 +167,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 5.2.0)

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -69,8 +69,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -110,8 +108,6 @@ GEM
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     racc (1.6.2)
@@ -187,7 +183,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 6.0.0)

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -73,8 +73,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -114,8 +112,6 @@ GEM
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     racc (1.6.2)
@@ -190,7 +186,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 6.1.0)

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -79,8 +79,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -120,8 +118,6 @@ GEM
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
-      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     racc (1.6.2)
@@ -189,7 +185,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 7.0.0)

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -92,8 +92,6 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.12.0)
-    forking_test_runner (1.13.0)
-      parallel_tests (>= 1.3.7)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -136,8 +134,6 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
-    parallel_tests (4.3.0)
-      parallel
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -224,7 +220,6 @@ PLATFORMS
 DEPENDENCIES
   bump
   bundler (<= 3)
-  forking_test_runner
   maxitest
   minitest-rails
   rails (~> 7.1.0)

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump'
   spec.add_development_dependency 'single_cov'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'forking_test_runner'
   spec.add_runtime_dependency 'actionpack', '>= 5.0', '< 7.2'
 
   spec.required_ruby_version = '>= 2.7.0'


### PR DESCRIPTION
Plain tests run in ~1 second on my machine, as opposed to ~3 seconds before. The forking_test_runner gem was introduced in fa0ea22409bb919958be73bbf0b519924a with the message “forking runner for better converage.” Curiously, the Singlecov numbers didn't change in that commit, and I don't know how coverage would be affected.

Of course, running each test in its own fork avoid pollution between tests. I don't think that is an issue here, mainly because it wasn't mentioned when the gem was added.