### PR TITLE
use standard indirectly via rubocop interface

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,12 +20,12 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails }}.gemfile
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - run: bundle exec rake test
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test
 
   linter:
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
         with:
           bundler-cache: true
       - name: linter
-        run: bundle exec rake standard
+        run: bundle exec rubocop
 
   # This wrapper is used in the main branch protection rules as a required check.
   # This way, we don’t need to update those rules when we add or remove a version in the test matrix.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+require:
+  - standard
+
+inherit_gem:
+  standard: config/base.yml
+
+AllCops:
+  SuggestExtensions: false
+  TargetRubyVersion: "2.7"
+  Exclude:
+    - vendor/**/*

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,0 @@
-ruby_version: 2.7

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "standard/rake"
 require "bump/tasks"
 
 # Pushing to rubygems is handled by a github workflow
 require "bundler/gem_tasks"
 ENV["gem_push"] = "false"
 
-task default: [:test, :standard]
+task default: [:test, :fmt]
 
 task :test do
   sh "forking-test-runner test --merge-coverage --quiet"
+end
+
+desc "Format code"
+task :fmt do
+  sh "rubocop --auto-correct"
 end
 
 desc "Bundle all gemfiles [CMD=]"


### PR DESCRIPTION
- makes ide integration work
- makes pre-commit work
- allows customization if anything goes wrong
- follows `go fmt` pattern