### PR TITLE
Drop upper limit on actionpack, test Rails main, release v2.23.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,11 +16,12 @@ jobs:
           - {ruby: '2.7', rails: '5.0'}
           - {ruby: '2.7', rails: '5.1'}
           - {ruby: '2.7', rails: '5.2'}
+          - {ruby: '3.3', rails: '_main'}
     name: ruby${{ matrix.ruby }} rails${{ matrix.rails }} rake test
     env:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails }}.gemfile
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -30,7 +31,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/rails_main_testing.yml
+++ b/.github/workflows/rails_main_testing.yml
@@ -1,0 +1,25 @@
+name: Test against Rails main
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  rails_main_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+    name: ruby${{ matrix.ruby }} rails_main rake test
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_main.gemfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/gemfiles/rails_main.gemfile.lock

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # NEXT
 
+- Drop upper limit on ActionPack, test with Rails main.
+
 # v2.22.0
 - rails 7.1 support
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # NEXT
 
+# v2.23.0
 - Drop upper limit on ActionPack, test with Rails main.
 
 # v2.22.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,11 @@
-PATH
-  remote: .
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 55c4adeb36eff229972eecbb53723c1b80393091
+  branch: main
   specs:
-    stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actionpack (7.1.3)
-      actionview (= 7.1.3)
-      activesupport (= 7.1.3)
+    actionpack (8.0.0.alpha)
+      actionview (= 8.0.0.alpha)
+      activesupport (= 8.0.0.alpha)
       nokogiri (>= 1.8.5)
       racc
       rack (>= 2.2.4)
@@ -17,28 +13,47 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actionview (7.1.3)
-      activesupport (= 7.1.3)
+      useragent (~> 0.16)
+    actionview (8.0.0.alpha)
+      activesupport (= 8.0.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (7.1.3)
+    activesupport (8.0.0.alpha)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      tzinfo (~> 2.0, >= 2.0.5)
+    railties (8.0.0.alpha)
+      actionpack (= 8.0.0.alpha)
+      activesupport (= 8.0.0.alpha)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+
+PATH
+  remote: .
+  specs:
+    stronger_parameters (2.22.0)
+      actionpack (>= 5.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
     builder (3.2.4)
     bump (0.10.0)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
     drb (2.2.0)
@@ -49,12 +64,13 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    irb (1.11.1)
-      rdoc
+    irb (1.14.0)
+      rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -62,10 +78,9 @@ GEM
       minitest (>= 5.14.0, < 5.21.0)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
-    minitest-rails (7.1.0)
+    minitest-rails (7.1.1)
       minitest (~> 5.20)
-      railties (~> 7.1.0)
-    mutex_m (0.2.0)
+      railties (>= 7.1.0, < 8.0.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -97,14 +112,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.1.3)
-      actionpack (= 7.1.3)
-      activesupport (= 7.1.3)
-      irb
-      rackup (>= 1.0.0)
-      rake (>= 12.2)
-      thor (~> 1.0, >= 1.2.2)
-      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
     rdoc (6.6.2)
@@ -149,6 +156,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    useragent (0.16.10)
     webrick (1.8.1)
     zeitwerk (2.6.13)
 
@@ -159,11 +167,11 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails
-  railties (~> 7.1.0)
+  railties!
   rake
   single_cov
   standard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GIT
 PATH
   remote: .
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -126,7 +126,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -126,7 +126,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -126,7 +126,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -128,7 +128,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -127,7 +127,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -127,7 +127,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    stronger_parameters (2.22.0)
+    stronger_parameters (2.23.0)
       actionpack (>= 5.0)
 
 GEM

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     stronger_parameters (2.22.0)
-      actionpack (>= 5.0, < 7.2)
+      actionpack (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -159,7 +159,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  bundler (< 2.5)
+  bundler
   forking_test_runner
   maxitest
   minitest-rails

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+gem "railties", github: "rails/rails", branch: "main"
+
+eval_gemfile "common.rb"

--- a/lib/stronger_parameters/version.rb
+++ b/lib/stronger_parameters/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StrongerParameters
-  VERSION = "2.22.0"
+  VERSION = "2.23.0"
 end

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob("lib/**/*") + %w[README.md]
 
-  spec.add_development_dependency "bundler", "< 2.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest-rails"
   spec.add_development_dependency "maxitest"
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "single_cov"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "forking_test_runner"
-  spec.add_runtime_dependency "actionpack", ">= 5.0", "< 7.2"
+  spec.add_runtime_dependency "actionpack", ">= 5.0"
 
   spec.required_ruby_version = ">= 2.7.0"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
Loosens Rails upper limit, tests with Rails main, releases v2.23.0.