### PR TITLE
Fix with Rails main

### DIFF
--- a/lib/stronger_parameters/parameters.rb
+++ b/lib/stronger_parameters/parameters.rb
@@ -147,7 +147,7 @@ module StrongerParameters
       end
     end
 
-    def hash_filter_with_stronger_parameters(params, filter)
+    def hash_filter_with_stronger_parameters(params, filter, **kwargs)
       stronger_filter = ActiveSupport::HashWithIndifferentAccess.new
       other_filter = ActiveSupport::HashWithIndifferentAccess.new
 
@@ -159,7 +159,7 @@ module StrongerParameters
         end
       end
 
-      hash_filter_without_stronger_parameters(params, other_filter)
+      hash_filter_without_stronger_parameters(params, other_filter, **kwargs)
 
       stronger_filter.each_key do |key|
         value = fetch(key, nil)

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -18,7 +18,11 @@ class BooksController < ActionController::Base
   end
 
   def create
-    params.require(:book).permit(id: Parameters.integer)
+    if Rails::VERSION::MAJOR >= 8
+      params.expect(book: {id: Parameters.integer})
+    else
+      params.require(:book).permit(id: Parameters.integer)
+    end
 
     head :ok
   end


### PR DESCRIPTION
Rails 8 adds `Parameters#expect` to safely filter and require params – see rails/rails#51674.

As far as I can tell, stronger_parameters should continue working. I have changed the controller test to call `#expect` when running Rails 8, but… it feels like we could use some more end-to-end testing of more complicated examples, e.g. some of those we have in the readme, like
```rb
params.permit(
  uid: (Parameters.string | Parameters.integer).required
)
```

This PR should fix [our Rails main tests](https://github.com/zendesk/stronger_parameters/actions/workflows/rails_main_testing.yml).