### PR TITLE
Remove minitest-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,9 +61,6 @@ GEM
       minitest (>= 5.14.0, < 5.25.0)
     mini_portile2 (2.8.7)
     minitest (5.24.1)
-    minitest-rails (7.1.1)
-      minitest (~> 5.20)
-      railties (>= 7.1.0, < 8.0.0)
     mutex_m (0.2.0)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
@@ -160,7 +157,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 7.1.0)
   rake
   single_cov

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 
 desc "Format code"
 task :fmt do
-  sh "rubocop --auto-correct"
+  sh "rubocop --autocorrect"
 end
 
 desc "Bundle all gemfiles [CMD=]"

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -46,9 +46,6 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.18.1)
-    minitest-rails (5.0.0)
-      minitest (~> 5.10)
-      railties (~> 5.0.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -129,7 +126,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 5.0.0)
   rake
   single_cov

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -46,9 +46,6 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.18.1)
-    minitest-rails (5.1.0)
-      minitest (~> 5.10)
-      railties (~> 5.1.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -129,7 +126,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 5.1.0)
   rake
   single_cov

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -46,9 +46,6 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.18.1)
-    minitest-rails (5.2.0)
-      minitest (~> 5.10)
-      railties (~> 5.2.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -129,7 +126,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 5.2.0)
   rake
   single_cov

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -47,9 +47,6 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
-    minitest-rails (6.0.2)
-      minitest (~> 5.10)
-      railties (~> 6.0.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -131,7 +128,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 6.0.0)
   rake
   single_cov

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -47,9 +47,6 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
-    minitest-rails (6.1.1)
-      minitest (~> 5.10)
-      railties (~> 6.1.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -130,7 +127,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 6.1.0)
   rake
   single_cov

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -46,9 +46,6 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
-    minitest-rails (7.0.1)
-      minitest (~> 5.10)
-      railties (~> 7.0.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -130,7 +127,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 7.0.0)
   rake
   single_cov

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -62,9 +62,6 @@ GEM
       minitest (>= 5.14.0, < 5.21.0)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
-    minitest-rails (7.1.0)
-      minitest (~> 5.20)
-      railties (~> 7.1.0)
     mutex_m (0.2.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
@@ -162,7 +159,6 @@ DEPENDENCIES
   bundler
   forking_test_runner
   maxitest
-  minitest-rails
   railties (~> 7.1.0)
   rake
   single_cov

--- a/stronger_parameters.gemspec
+++ b/stronger_parameters.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest-rails"
   spec.add_development_dependency "maxitest"
   spec.add_development_dependency "bump"
   spec.add_development_dependency "single_cov"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,10 @@ ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
 
 require "action_pack"
 require "stronger_parameters"
-require "minitest/rails"
+
+# Add spec DSL to the TestCase class
+# This is all we needed from minitest-rails
+ActiveSupport.on_load(:active_support_test_case) { extend Minitest::Spec::DSL }
 
 # Use ActionController::TestCase for Controllers
 Minitest::Spec::DSL::TYPES.unshift [/Controller$/, ActionController::TestCase]


### PR DESCRIPTION
There is currently no version of minitest-rails that is compatible with
Rails 7.2 or 8.0. Open pull requests in the repo are not being reviewed.

It seems we don't use the gem for anything other than adding minitest's
Spec::DLS to ActiveSupport::TestCase, and that we can just as easily do
ourselves.
